### PR TITLE
README: point readers at a client that consumes the artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@
 | `distribution.sqlite.gz` | 同内容的 SQLite 打包,义项带优先级索引列,客户端可直接查询 |
 | `audit.jsonl.gz` | 审计工件:保留 curated 层与生成层的完整分离视图 |
 
+## 客户端
+
+不想自己处理工件的话,[**Aictionary**](https://github.com/ahpxex/Aictionary) 是一个
+现成的桌面客户端(Tauri 2 + React,macOS / Windows / Linux):它消费
+`distribution_entry_v5` 契约,从本仓库的 Release 下载 `distribution.sqlite.gz`
+到本地,查询全部离线完成,并按契约实现了义项优先级折叠、关系词分组与 US/UK
+音标聚合等展示规则。本仓库只负责数据,客户端的问题请到该仓库反馈。
+
 ## 词条长什么样
 
 每个词条包含:一条贯穿主要义项的**记忆主线**、三级**义项优先级**


### PR DESCRIPTION
The README explains how to download the three artifacts and what `distribution_entry_v5` looks like, then leaves anyone who just wants to look words up to build something themselves.

[Aictionary](https://github.com/ahpxex/Aictionary) already consumes this contract end to end — downloads `distribution.sqlite.gz` from this repo's releases, queries it entirely offline, and implements the display rules the contract specifies (sense-priority folding, relation grouping, US/UK pronunciation aggregation). Adding a short section where the artifacts are introduced, with the boundary stated: this repo owns the data, client issues go to the client.

Wording follows the file's existing punctuation style. No other changes.

The reciprocal credit is in place on the other side — Aictionary's README and its About pane now name this repo as the source and carry the CC BY-SA 4.0 attribution for the data.